### PR TITLE
Bug/field exist checks

### DIFF
--- a/scripts/Corelight/CommunityID/__load__.zeek
+++ b/scripts/Corelight/CommunityID/__load__.zeek
@@ -22,5 +22,4 @@
 @load ./ssh
 @load ./ssl
 @load ./syslog
-@load ./tunnel
 @endif

--- a/scripts/Corelight/CommunityID/__load__.zeek
+++ b/scripts/Corelight/CommunityID/__load__.zeek
@@ -1,7 +1,6 @@
 @ifdef (CommunityID::hash_conn)
 @load ./connection
 @load ./dce_rpc
-#@load ./dhcp
 @load ./dnp3
 @load ./dns
 @load ./ftp

--- a/scripts/Corelight/CommunityID/dce_rpc.zeek
+++ b/scripts/Corelight/CommunityID/dce_rpc.zeek
@@ -7,14 +7,20 @@ export {
 
 event dce_rpc_request(c: connection, fid: count, ctx_id: count, opnum: count, stub_len: count)
     {
-    if ( ! c$dce_rpc?$community_id && c?$community_id )
-        c$dce_rpc$community_id = c$community_id;
+    if ( c?$dce_rpc )
+        {
+        if ( ! c$dce_rpc?$community_id && c?$community_id )
+            c$dce_rpc$community_id = c$community_id;
+        }
     }
 
 event dce_rpc_response(c: connection, fid: count, ctx_id: count, opnum: count, stub_len: count)
     {
-    if ( ! c$dce_rpc?$community_id && c?$community_id )
-        c$dce_rpc$community_id = c$community_id;
+    if ( c?$dce_rpc )
+        {
+        if ( ! c$dce_rpc?$community_id && c?$community_id )
+            c$dce_rpc$community_id = c$community_id;
+        }
     }
 
 @endif

--- a/scripts/Corelight/CommunityID/dhcp.zeek
+++ b/scripts/Corelight/CommunityID/dhcp.zeek
@@ -1,5 +1,0 @@
-export {
-redef record DHCP::Info += {
-        cummunity_id: string &optional &log;
-};
-}

--- a/scripts/Corelight/CommunityID/dnp3.zeek
+++ b/scripts/Corelight/CommunityID/dnp3.zeek
@@ -8,14 +8,20 @@ export {
 
 event dnp3_application_request_header(c: connection, is_orig: bool, application: count, fc: count)
     {
-    if ( ! c$dnp3?$community_id && c?$community_id )
-        c$dnp3$community_id = c$community_id;
+    if ( c?$dnp3 )
+        {
+        if ( ! c$dnp3?$community_id && c?$community_id )
+            c$dnp3$community_id = c$community_id;
+        }
     }
 
 event dnp3_application_response_header(c: connection, is_orig: bool, application: count, fc: count, iin: count)
     {
-    if ( ! c$dnp3?$community_id && c?$community_id )
-        c$dnp3$community_id = c$community_id;
+    if ( c?$dnp3 )
+        {
+        if ( ! c$dnp3?$community_id && c?$community_id )
+            c$dnp3$community_id = c$community_id;
+        }
     }
 
 @endif

--- a/scripts/Corelight/CommunityID/dns.zeek
+++ b/scripts/Corelight/CommunityID/dns.zeek
@@ -9,15 +9,20 @@ export {
 
 event dns_request(c: connection, msg: dns_msg, query: string, qtype: count, qclass: count) &priority=-5
     {
-    # new_connection is not being triggered for UDP, so we need another plan 
-    if (! c$dns?$community_id && c?$community_id)
-        c$dns$community_id = c$community_id;
+    if ( c?$dns ) 
+        {
+        if (! c$dns?$community_id && c?$community_id)
+            c$dns$community_id = c$community_id;
+        }
     }
 
 event dns_end(c: connection, msg: dns_msg)
     {
-    if (! c$dns?$community_id && c?$community_id)
-        c$dns$community_id = c$community_id;
+    if ( c?$dns ) 
+        {
+        if (! c$dns?$community_id && c?$community_id)
+            c$dns$community_id = c$community_id;
+        }
     }
 
 @endif

--- a/scripts/Corelight/CommunityID/ftp.zeek
+++ b/scripts/Corelight/CommunityID/ftp.zeek
@@ -8,14 +8,20 @@ export {
 
 event ftp_request(c: connection, command: string, arg: string)
     {
-    if ( ! c$ftp?$community_id && c?$community_id )
-        c$ftp$community_id = c$community_id;
+    if ( c?$ftp )
+        {
+        if ( ! c$ftp?$community_id && c?$community_id )
+            c$ftp$community_id = c$community_id;
+        }
     }
 
 event ftp_reply(c: connection, code: count, msg: string, cont_resp: bool)
     {
-    if ( ! c$ftp?$community_id && c?$community_id )
-        c$ftp$community_id = c$community_id;
+    if ( c?$ftp )
+        {
+        if ( ! c$ftp?$community_id && c?$community_id )
+            c$ftp$community_id = c$community_id;
+        }
     }
 
 @endif

--- a/scripts/Corelight/CommunityID/http.zeek
+++ b/scripts/Corelight/CommunityID/http.zeek
@@ -9,14 +9,20 @@ export {
 
 event http_request(c: connection, method: string, original_URI: string, unescaped_URI: string, version: string)
     {
-    if (! c$http?$community_id && c?$community_id)
-        c$http$community_id = c$community_id;
+    if ( c?$http )
+        {
+        if (! c$http?$community_id && c?$community_id)
+            c$http$community_id = c$community_id;
+        }
     }
 
 event http_reply(c: connection, version: string, code: count, reason: string)
     {
-    if (! c$http?$community_id && c?$community_id)
-        c$http$community_id = c$community_id;
+    if ( c?$http )
+        {
+        if (! c$http?$community_id && c?$community_id)
+            c$http$community_id = c$community_id;
+        }
     }
 
 @endif

--- a/scripts/Corelight/CommunityID/irc.zeek
+++ b/scripts/Corelight/CommunityID/irc.zeek
@@ -7,14 +7,20 @@ export {
 }
 event irc_request(c: connection, is_orig: bool, prefix: string, command: string, arguments: string)
     {
-    if ( ! c$irc?$community_id && c?$community_id )
-        c$irc$community_id = c$community_id;
+    if ( c?$dns )
+        {
+        if ( ! c$irc?$community_id && c?$community_id )
+            c$irc$community_id = c$community_id;
+        }
     }
 
 event irc_reply(c: connection, is_orig: bool, prefix: string, code: count, params: string)
     {
-    if ( ! c$irc?$community_id && c?$community_id )
-        c$irc$community_id = c$community_id;
+    if ( c?$dns )
+        {
+        if ( ! c$irc?$community_id && c?$community_id )
+            c$irc$community_id = c$community_id;
+        }
     }
 
 @endif

--- a/scripts/Corelight/CommunityID/krb.zeek
+++ b/scripts/Corelight/CommunityID/krb.zeek
@@ -8,38 +8,56 @@ export {
 
 event krb_ap_request(c: connection, ticket: KRB::Ticket, opts: KRB::AP_Options)
     {
-    if ( ! c$krb?$community_id && c?$community_id )
-        c$krb$community_id = c$community_id;  
+    if ( c?$krb )
+        {
+        if ( ! c$krb?$community_id && c?$community_id )
+            c$krb$community_id = c$community_id;  
+        }
     }
 
 event krb_ap_response(c: connection)
     {
-    if ( ! c$krb?$community_id && c?$community_id )
-        c$krb$community_id = c$community_id;
+    if ( c?$krb )
+        {
+        if ( ! c$krb?$community_id && c?$community_id )
+            c$krb$community_id = c$community_id;  
+        }
     }
 
 event krb_as_request(c: connection, msg: KRB::KDC_Request)
     {
-    if ( ! c$krb?$community_id && c?$community_id )
-        c$krb$community_id = c$community_id;
+    if ( c?$krb )
+        {
+        if ( ! c$krb?$community_id && c?$community_id )
+            c$krb$community_id = c$community_id;  
+        }
     }
 
 event krb_as_response(c: connection, msg: KRB::KDC_Response)
     {
-    if ( ! c$krb?$community_id && c?$community_id )
-        c$krb$community_id = c$community_id;
+    if ( c?$krb )
+        {
+        if ( ! c$krb?$community_id && c?$community_id )
+            c$krb$community_id = c$community_id;  
+        }
     }
 
 event krb_tgs_request(c: connection, msg: KRB::KDC_Request)
     {
-    if ( ! c$krb?$community_id && c?$community_id )
-        c$krb$community_id = c$community_id;
+    if ( c?$krb )
+        {
+        if ( ! c$krb?$community_id && c?$community_id )
+            c$krb$community_id = c$community_id;  
+        }
     }
 
 event krb_tgs_response(c: connection, msg: KRB::KDC_Response)
     {
-    if ( ! c$krb?$community_id && c?$community_id )
-        c$krb$community_id = c$community_id;
+    if ( c?$krb )
+        {
+        if ( ! c$krb?$community_id && c?$community_id )
+            c$krb$community_id = c$community_id;  
+        }
     }
     
 @endif

--- a/scripts/Corelight/CommunityID/modbus.zeek
+++ b/scripts/Corelight/CommunityID/modbus.zeek
@@ -7,7 +7,10 @@ export {
 
 event modbus_message(c: connection, headers: ModbusHeaders, is_orig: bool)
     {
-    if ( ! c$modbus?$community_id && c?$community_id )
-        c$modbus$community_id = c$community_id;
+    if ( c?$modbus )
+        {
+        if ( ! c$modbus?$community_id && c?$community_id )
+            c$modbus$community_id = c$community_id;
+        }
     }
 @endif

--- a/scripts/Corelight/CommunityID/mysql.zeek
+++ b/scripts/Corelight/CommunityID/mysql.zeek
@@ -7,19 +7,28 @@ export {
 
 event mysql_command_request(c: connection, command: count, arg: string)
     {
-    if ( ! c$mysql?$community_id && c?$community_id )
-        c$mysql$community_id = c$community_id;
+    if ( c?$mysql)
+        {
+        if ( ! c$mysql?$community_id && c?$community_id )
+            c$mysql$community_id = c$community_id;
+        }
     }
 
 event mysql_error(c: connection, code: count, msg: string)
     {
-    if ( ! c$mysql?$community_id && c?$community_id )
-        c$mysql$community_id = c$community_id;
+    if ( c?$mysql)
+        {
+        if ( ! c$mysql?$community_id && c?$community_id )
+            c$mysql$community_id = c$community_id;
+        }
     }
 
 event mysql_ok(c: connection, affected_rows: count)
     {
-    if ( ! c$mysql?$community_id && c?$community_id )
-        c$mysql$community_id = c$community_id;
+    if ( c?$mysql)
+        {
+        if ( ! c$mysql?$community_id && c?$community_id )
+            c$mysql$community_id = c$community_id;
+        }
     }
 @endif

--- a/scripts/Corelight/CommunityID/ntlm.zeek
+++ b/scripts/Corelight/CommunityID/ntlm.zeek
@@ -7,31 +7,46 @@ export {
 
 event ntlm_authenticate(c: connection, request: NTLM::Authenticate)
     {
-    if ( ! c$ntlm?$community_id && c?$community_id )
-        c$ntlm$community_id = c$community_id;
+    if ( c?$ntlm )
+        {
+        if ( ! c$ntlm?$community_id && c?$community_id )
+            c$ntlm$community_id = c$community_id;
+        }
     }
 
 event ntlm_challenge(c: connection, challenge: NTLM::Challenge)
     {
-    if ( ! c$ntlm?$community_id && c?$community_id )
-        c$ntlm$community_id = c$community_id;
+    if ( c?$ntlm )
+        {
+        if ( ! c$ntlm?$community_id && c?$community_id )
+            c$ntlm$community_id = c$community_id;
+        }
     }
 
 event ntlm_challenge(c: connection, challenge: NTLM::Challenge)
     {
-    if ( ! c$ntlm?$community_id && c?$community_id )
-        c$ntlm$community_id = c$community_id;
+    if ( c?$ntlm )
+        {
+        if ( ! c$ntlm?$community_id && c?$community_id )
+            c$ntlm$community_id = c$community_id;
+        }
     }
 
 event ntlm_challenge(c: connection, challenge: NTLM::Challenge)
     {
-    if ( ! c$ntlm?$community_id && c?$community_id )
-        c$ntlm$community_id = c$community_id;
+    if ( c?$ntlm )
+        {
+        if ( ! c$ntlm?$community_id && c?$community_id )
+            c$ntlm$community_id = c$community_id;
+        }
     }
 
 event ntlm_negotiate(c: connection, negotiate: NTLM::Negotiate)
     {
-    if ( ! c$ntlm?$community_id && c?$community_id )
-        c$ntlm$community_id = c$community_id;
+    if ( c?$ntlm )
+        {
+        if ( ! c$ntlm?$community_id && c?$community_id )
+            c$ntlm$community_id = c$community_id;
+        }
     }
 @endif

--- a/scripts/Corelight/CommunityID/ntp.zeek
+++ b/scripts/Corelight/CommunityID/ntp.zeek
@@ -7,7 +7,10 @@ export {
 
 event ntp_message(c: connection, is_orig: bool, msg: NTP::Message)
     {
-    if ( ! c$ntp?$community_id && c?$community_id )
-        c$ntp$community_id = c$community_id; 
+    if ( c?$ntp )
+        {
+        if ( ! c$ntp?$community_id && c?$community_id )
+            c$ntp$community_id = c$community_id; 
+        }
     }
 @endif

--- a/scripts/Corelight/CommunityID/radius.zeek
+++ b/scripts/Corelight/CommunityID/radius.zeek
@@ -8,8 +8,11 @@ export {
 
 event radius_message(c: connection, result: RADIUS::Message)
     {
-    if ( ! c$radius?$community_id && c?$community_id )
-        c$radius$community_id = c$community_id;
+    if ( c?$radius )
+        {
+        if ( ! c$radius?$community_id && c?$community_id )
+            c$radius$community_id = c$community_id;
+        }
     }
 
 @endif

--- a/scripts/Corelight/CommunityID/rdp.zeek
+++ b/scripts/Corelight/CommunityID/rdp.zeek
@@ -7,20 +7,29 @@ export {
 
 event rdp_connect_request(c: connection, cookie: string)
     {
-    if ( ! c$rdp?$community_id && c?$community_id )
-        c$rdp$community_id = c$community_id;       
+    if ( c?$rdp )
+        {
+        if ( ! c$rdp?$community_id && c?$community_id )
+            c$rdp$community_id = c$community_id;       
+        }
     }
 
 event rdp_negotiation_failure(c: connection, failure_code: count)
     {
-    if ( ! c$rdp?$community_id && c?$community_id )
-        c$rdp$community_id = c$community_id;
+    if ( c?$rdp )
+        {
+        if ( ! c$rdp?$community_id && c?$community_id )
+            c$rdp$community_id = c$community_id;       
+        }
     }
 
 event rdp_negotiation_response(c: connection, security_protocol: count)
     {
-    if ( ! c$rdp?$community_id && c?$community_id )
-        c$rdp$community_id = c$community_id;
+    if ( c?$rdp )
+        {
+        if ( ! c$rdp?$community_id && c?$community_id )
+            c$rdp$community_id = c$community_id;       
+        }
     }
 @endif
 

--- a/scripts/Corelight/CommunityID/rfb.zeek
+++ b/scripts/Corelight/CommunityID/rfb.zeek
@@ -7,14 +7,20 @@ export {
 
 event rfb_client_version(c: connection, major_version: string, minor_version: string)
     {
-    if ( ! c$rfb?$community_id && c?$community_id )
-        c$rfb$community_id = c$community_id;
+    if ( c?$rfb )
+        {
+        if ( ! c$rfb?$community_id && c?$community_id )
+            c$rfb$community_id = c$community_id;
+        }
     }
 
 event rfb_server_version(c: connection, major_version: string, minor_version: string)
     {
-    if ( ! c$rfb?$community_id && c?$community_id )
-        c$rfb$community_id = c$community_id;
+    if ( c?$rfb )
+        {
+        if ( ! c$rfb?$community_id && c?$community_id )
+            c$rfb$community_id = c$community_id;
+        }
     }
 
 @endif 

--- a/scripts/Corelight/CommunityID/sip.zeek
+++ b/scripts/Corelight/CommunityID/sip.zeek
@@ -7,13 +7,19 @@ export {
 
 event sip_reply(c: connection, version: string, code: count, reason: string)
     {
-    if ( ! c$sip?$community_id && c?$community_id )
-        c$sip$community_id = c$community_id;
+    if ( c?$sip )
+        {
+        if ( ! c$sip?$community_id && c?$community_id )
+            c$sip$community_id = c$community_id;
+        }
     }
 
 event sip_request(c: connection, method: string, original_URI: string, version: string)
     {
-    if ( ! c$sip?$community_id && c?$community_id )
-        c$sip$community_id = c$community_id;
+    if ( c?$sip )
+        {
+        if ( ! c$sip?$community_id && c?$community_id )
+            c$sip$community_id = c$community_id;
+        }
     }
 @endif

--- a/scripts/Corelight/CommunityID/smb.zeek
+++ b/scripts/Corelight/CommunityID/smb.zeek
@@ -26,35 +26,53 @@ export {
 event smb1_message(c: connection, hdr: SMB1::Header, is_orig: bool) &priority=-10
     {
     @ifdef (SMB::CmdInfo)
-    if ( c$smb_state?$current_cmd && ! c$smb_state$current_cmd?$community_id && c?$community_id )
-        c$smb_state$current_cmd$community_id = c$community_id;
+    if ( c?$smb_state )
+        {
+        if ( c$smb_state?$current_cmd && ! c$smb_state$current_cmd?$community_id && c?$community_id )
+            c$smb_state$current_cmd$community_id = c$community_id;
+        }
     @endif
 
     @ifdef (SMB::FileInfo)
-    if ( c$smb_state?$current_file && ! c$smb_state$current_file?$community_id && c?$community_id )
-        c$smb_state$current_file$community_id = c$community_id;
+    if ( c?$smb_state )
+        {
+        if ( c$smb_state?$current_file && ! c$smb_state$current_file?$community_id && c?$community_id )
+            c$smb_state$current_file$community_id = c$community_id;
+        }
     @endif
 
     @ifdef (SMB::TreeInfo)
-    if ( c$smb_state?$current_tree && ! c$smb_state$current_tree?$community_id && c?$community_id )
-        c$smb_state$current_tree$community_id = c$community_id;
+    if ( c?$smb_state )
+        {
+        if ( c$smb_state?$current_tree && ! c$smb_state$current_tree?$community_id && c?$community_id )
+            c$smb_state$current_tree$community_id = c$community_id;
+        }
     @endif
     }
 
 event smb2_message(c: connection, hdr: SMB2::Header, is_orig: bool) &priority=-10
     {
     @ifdef (SMB::CmdInfo)
-    if ( c$smb_state?$current_cmd && ! c$smb_state$current_cmd?$community_id && c?$community_id )
-        c$smb_state$current_cmd$community_id = c$community_id;
+    if ( c?$smb_state )
+        {
+        if ( c$smb_state?$current_cmd && ! c$smb_state$current_cmd?$community_id && c?$community_id )
+            c$smb_state$current_cmd$community_id = c$community_id;
+        }
     @endif
 
     @ifdef (SMB::FileInfo)
-    if ( c$smb_state?$current_file && ! c$smb_state$current_file?$community_id && c?$community_id )
-        c$smb_state$current_file$community_id = c$community_id;
+    if ( c?$smb_state )
+        {
+        if ( c$smb_state?$current_file && ! c$smb_state$current_file?$community_id && c?$community_id )
+            c$smb_state$current_file$community_id = c$community_id;
+        }
     @endif
 
     @ifdef (SMB::TreeInfo)
-    if ( c$smb_state?$current_tree && ! c$smb_state$current_tree?$community_id && c?$community_id )
-        c$smb_state$current_tree$community_id = c$community_id;
+    if ( c?$smb_state )
+        {
+        if ( c$smb_state?$current_tree && ! c$smb_state$current_tree?$community_id && c?$community_id )
+            c$smb_state$current_tree$community_id = c$community_id;
+        }
     @endif
     }

--- a/scripts/Corelight/CommunityID/smtp.zeek
+++ b/scripts/Corelight/CommunityID/smtp.zeek
@@ -8,13 +8,19 @@ export {
 
 event smtp_reply(c: connection, is_orig: bool, code: count, cmd: string, msg: string, cont_resp: bool)
     {
-    if ( ! c$smtp?$community_id && c?$community_id )
-        c$smtp$community_id = c$community_id;
+    if ( c?$smtp )
+        {
+        if ( ! c$smtp?$community_id && c?$community_id )
+            c$smtp$community_id = c$community_id;
+        }
     }
 
 event smtp_request(c: connection, is_orig: bool, command: string, arg: string)
     {
-    if ( ! c$smtp?$community_id && c?$community_id )
-        c$smtp$community_id = c$community_id;
+    if ( c?$smtp )
+        {
+        if ( ! c$smtp?$community_id && c?$community_id )
+            c$smtp$community_id = c$community_id;
+        }
     }
 @endif 

--- a/scripts/Corelight/CommunityID/snmp.zeek
+++ b/scripts/Corelight/CommunityID/snmp.zeek
@@ -7,19 +7,28 @@ export {
 
 event snmp_get_request(c: connection , is_orig: bool , header: SNMP::Header , pdu: SNMP::PDU)
     {
-    if ( ! c$snmp?$community_id && c?$community_id )
-        c$snmp$community_id = c$community_id;
+    if ( c?$snmp )
+        {
+        if ( ! c$snmp?$community_id && c?$community_id )
+            c$snmp$community_id = c$community_id;
+        }
     }
 
 event snmp_set_request(c: connection , is_orig: bool , header: SNMP::Header , pdu: SNMP::PDU)
     {
-    if ( ! c$snmp?$community_id && c?$community_id )
-        c$snmp$community_id = c$community_id;
+    if ( c?$snmp )
+        {
+        if ( ! c$snmp?$community_id && c?$community_id )
+            c$snmp$community_id = c$community_id;
+        }
     }
 
 event snmp_response(c: connection , is_orig: bool , header: SNMP::Header , pdu: SNMP::PDU)
     {
-    if ( ! c$snmp?$community_id && c?$community_id )
-        c$snmp$community_id = c$community_id;
+    if ( c?$snmp )
+        {
+        if ( ! c$snmp?$community_id && c?$community_id )
+            c$snmp$community_id = c$community_id;
+        }
     }
 @endif

--- a/scripts/Corelight/CommunityID/socks.zeek
+++ b/scripts/Corelight/CommunityID/socks.zeek
@@ -8,13 +8,19 @@ export {
 
 event socks_reply(c: connection, version: count, reply: count, sa: SOCKS::Address, p: port)
     {
-    if ( ! c$socks?$community_id && c?$community_id )
-        c$socks$community_id = c$community_id;
+    if ( c?$socks )
+        {
+        if ( ! c$socks?$community_id && c?$community_id )
+            c$socks$community_id = c$community_id;
+        }
     }
 
 event socks_request(c: connection, version: count, request_type: count, sa: SOCKS::Address, p: port, user: string)
     {
-    if ( ! c$socks?$community_id && c?$community_id )
-        c$socks$community_id = c$community_id;
+    if ( c?$socks )
+        {
+        if ( ! c$socks?$community_id && c?$community_id )
+            c$socks$community_id = c$community_id;
+        }
     }
 @endif

--- a/scripts/Corelight/CommunityID/ssh.zeek
+++ b/scripts/Corelight/CommunityID/ssh.zeek
@@ -7,14 +7,20 @@ export {
 
 event ssh_client_version(c: connection, version: string)
     {
-    if ( ! c$ssh?$community_id && c?$community_id )
-        c$ssh$community_id = c$community_id;
+    if ( c?$ssh )
+        {
+        if ( ! c$ssh?$community_id && c?$community_id )
+            c$ssh$community_id = c$community_id;
+        }
     }
 
 event ssh_server_version(c: connection, version: string)
     {
-    if ( ! c$ssh?$community_id && c?$community_id )
-        c$ssh$community_id = c$community_id;
+    if ( c?$ssh )
+        {
+        if ( ! c$ssh?$community_id && c?$community_id )
+            c$ssh$community_id = c$community_id;
+        }
     }
 
 @endif

--- a/scripts/Corelight/CommunityID/ssl.zeek
+++ b/scripts/Corelight/CommunityID/ssl.zeek
@@ -7,14 +7,20 @@ export {
 
 event ssl_client_hello(c: connection, version: count, record_version: count, possible_ts: time, client_random: string, session_id: string, ciphers: index_vec, comp_methods: index_vec)
     {
-    if ( c?$community_id )
-        c$ssl$community_id = c$community_id;
+    if ( c?$ssl )
+        {
+        if ( ! c$ssl?$community_id && c?$community_id )
+            c$ssl$community_id = c$community_id;
+        }
     }
 
 event ssl_server_hello(c: connection, version: count, record_version: count, possible_ts: time, server_random: string, session_id: string, cipher: count, comp_method: count)
     {
-    if ( ! c$ssl?$community_id && c?$community_id )
-        c$ssl$community_id = c$community_id;    
+    if ( c?$ssl )
+        {
+        if ( ! c$ssl?$community_id && c?$community_id )
+            c$ssl$community_id = c$community_id;
+        }
     }
 
 @endif

--- a/scripts/Corelight/CommunityID/syslog.zeek
+++ b/scripts/Corelight/CommunityID/syslog.zeek
@@ -7,8 +7,11 @@ export {
 
 event syslog_message(c: connection, facility: count, severity: count, msg: string)
     {
-    if ( !c$syslog?$community_id && c?$community_id )
-        c$syslog$community_id = c$community_id;
+    if ( c?$syslog )
+        {
+        if ( !c$syslog?$community_id && c?$community_id )
+            c$syslog$community_id = c$community_id;
+        }
     }
 
 @endif

--- a/scripts/Corelight/CommunityID/tunnel.zeek
+++ b/scripts/Corelight/CommunityID/tunnel.zeek
@@ -1,9 +1,0 @@
-### No suitable events for accessing connection and Tunnel::Info records
-
-@ifdef (Tunnel::Info)
-export {
-    redef record Tunnel::Info += {
-        community_id: string &optional &log;
-    };
-}
-@endif

--- a/scripts/__load__.zeek
+++ b/scripts/__load__.zeek
@@ -1,9 +1,0 @@
-#
-# This is loaded automatically at startup once the plugin gets activated
-# and its BiF elements have become available. Include code here that should
-# always execute unconditionally at that time. 
-# 
-# Note that often you may want your plugin's accompanying scripts not here, but
-# in scripts/<plugin-namespace>/<plugin-name>/__load__.bro. That's processed
-# only on explicit `@load <plugin-namespace>/<plugin-name>`.
-#


### PR DESCRIPTION
This PR adds conditions to verify that protocol record fields have been initialized before they are accessed.  There appear to be lurking race conditions in Zeek where a protocol analyzer will fire off an event (ex dns_request) before the `dns` field has been added to the connection record.  